### PR TITLE
docs: document per-edit commit enforcement

### DIFF
--- a/.windsurf/cascade-rules.md
+++ b/.windsurf/cascade-rules.md
@@ -22,9 +22,10 @@
 
 ## Atomic Commits Rules
 - **Single Purpose**: Each commit should represent one logical change (new service, config update, documentation, etc.)
+- **One Edit, One Commit**: Every file edit must land in its own commit with a clear summary so Cascade/MCP automation can map changes back to their originating tasks
 - **PR Linking**: Pull requests must link to relevant ADRs or backlog issues
 - **Commit Messages**: Use conventional commit format: type(scope): description
-- **No Mixed Changes**: Don't mix unrelated changes in a single commit
+- **No Mixed Changes**: Don't mix unrelated changes in a single commit; the automation enforces this by validating per-edit commits
 
 ## Infrastructure as Code (IaC) Clarity Rules
 - **Compose Organization**: Keep docker-compose.yml clean and organized by service type

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ repo-root/
 
 ### Code Standards
 - **Python**: Black formatting, type hints, comprehensive error handling
-- **Commits**: Conventional commit format with issue/PR references
+- **Commits**: Conventional commit format with issue/PR references, and land every edit in its own descriptive commit so Cascade/MCP automation can trace task boundaries
 - **Tests**: Unit tests for all business logic
 - **Documentation**: Update README and docs for user-facing changes
 


### PR DESCRIPTION
## Summary
- emphasize the per-edit commit requirement in the cascade rules, including its tie-in to Cascade/MCP automation
- update the README code standards to highlight per-edit descriptive commits so contributors follow the automation expectations

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e1ad3733a88322927c0094abc50896