### PR TITLE
feat: enforce descriptive commit summary metadata

### DIFF
--- a/.windsurf/cascade-examples.md
+++ b/.windsurf/cascade-examples.md
@@ -47,12 +47,23 @@ When a developer creates a task to scaffold a new service component:
    - Description: "Create branch and commit scaffold setup for writer"
    - Priority: "medium"
    - Labels: ["git", "branch", "commit"]
+   - Metadata:
+     - `git.commitMessageGuidance.summaryTemplate`: "Provide a descriptive summary of writer changes"
+     - `git.commitMessageGuidance.summaryField`: `descriptive_summary`
+     - `git.commitMessageGuidance.styleGuide`: "Use present tense, highlight primary impact, limit to 72 characters"
+
+5. **Commit summary validation**
+   - Component: "commit-validation"
+   - Description: "Validate descriptive summary commit for writer"
+   - Priority: "medium"
+   - Labels: ["git", "commit", "validation"]
+   - Metadata checklist ensures a summary-backed commit exists and is captured for release notes
 
 ### Generated Task Tree
 
 ```
 📋 Original Task: scaffold service-writer
-└── 🎯 Service Scaffold Cascade (4 subtasks)
+└── 🎯 Service Scaffold Cascade (5 subtasks)
     ├── 🔧 Writer Service Scaffolding
     │   ├── HTTP skeleton with /health & /metrics endpoints
     │   ├── Dockerfile with healthcheck
@@ -67,7 +78,8 @@ When a developer creates a task to scaffold a new service component:
     │   └── README.md updates with writer service info
     └── 🔀 Git Workflow Setup
         ├── feature/writer-scaffold branch creation
-        ├── Initial commit of service scaffolding
+        ├── Initial commit of service scaffolding with descriptive summary guidance
+        ├── Validation checklist to confirm the summary-backed commit exists
         └── PR template with proper labels and ADR references
 ```
 

--- a/.windsurf/cascade-rules.yaml
+++ b/.windsurf/cascade-rules.yaml
@@ -104,6 +104,26 @@ cascadeRules:
           description: "Commit ${component} changes with conventional format"
           priority: "medium"
           labels: ["git", "commit"]
+          metadata:
+            git:
+              commitMessageGuidance:
+                requiresDescriptiveSummary: true
+                summaryField: "descriptive_summary"
+                summaryTemplate: "Provide a descriptive summary of ${component} changes"
+                styleGuide: "Use present tense, highlight primary impact, limit to 72 characters"
+      - createTask:
+          component: "commit-validation"
+          description: "Validate descriptive summary commit for ${component}"
+          priority: "medium"
+          labels: ["git", "commit", "validation"]
+          metadata:
+            git:
+              validation:
+                requiresSummaryCheck: true
+                summaryField: "descriptive_summary"
+                checklist:
+                  - "Confirm commit exists with descriptive summary"
+                  - "Ensure summary text is copied into release notes tracker"
       - createTask:
           component: "pr"
           description: "Create PR with proper labels and ADR references"


### PR DESCRIPTION
## Summary
- add descriptive commit summary metadata and validation task to the Git workflow cascade
- teach the Task Master server to merge interpolated metadata from cascade actions and document the new guidance
- extend cascade unit tests to cover commit summary guidance propagation

## Testing
- pytest test_task_master_server.py

------
https://chatgpt.com/codex/tasks/task_e_68e1ad3616c08322933ce9f5bbb56d28