### PR TITLE
feat: automate github issue workflows

### DIFF
--- a/.windsurf/cascade-rules.yaml
+++ b/.windsurf/cascade-rules.yaml
@@ -294,6 +294,23 @@ cascadeRules:
           body: "${task.description}"
           labels: ["wave2-poc","ready-for-dev"]
 
+  - name: "Close GitHub issues when tasks complete"
+    trigger:
+      whenTool: "task-master.task_update"
+      condition:
+        statusEquals: "completed"
+        metadataPath: "github.issue_number"
+    actions:
+      - tool: "github.comment_issue"
+        with:
+          number: "${task.metadata.github.issue_number}"
+          body: "Task ${task.title} marked completed automatically by Task Master."
+      - tool: "github.close_issue"
+        with:
+          number: "${task.metadata.github.issue_number}"
+          reason: "completed"
+    labels: ["github", "automation", "issue-triage"]
+
 # --- global config stays as-is ---
 globalConfig:
   maxConcurrentTasks: 10

--- a/.windsurf/mcp.json
+++ b/.windsurf/mcp.json
@@ -60,6 +60,7 @@
       "tools": [
         "github.ensure_labels",
         "github.create_issue",
+        "github.update_issue",
         "github.comment_issue",
         "github.close_issue"
       ]


### PR DESCRIPTION
## Summary
- add a github.update_issue tool to the GitHub MCP server and expose it in the Windsurf configuration to support richer issue maintenance
- extend the task master server with GitHub-aware helpers that create issues on task creation, synchronize updates, and close issues on completion while enriching cascade automation rules
- cover the automation with dedicated unit tests that mock the GitHub CLI flow for creation and completion scenarios

## Testing
- pytest test_task_master_server.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b0dea81c83229aea886ed207ee43